### PR TITLE
Fix bug with the number of episodes in the watched one

### DIFF
--- a/app/(pages)/(content)/anime/[slug]/components/actions/components/watch-stats.tsx
+++ b/app/(pages)/(content)/anime/[slug]/components/actions/components/watch-stats.tsx
@@ -30,24 +30,27 @@ const WatchStats = () => {
         if (watch) {
             const episodes =
                 (variables?.params?.episodes || watch.episodes) + 1;
-            let status = watch.status;
 
-            if (episodes === watch.anime.episodes_total) {
-                status = 'completed';
+            if (episodes <= watch.anime.episodes_total || !watch.anime.episodes_total) {
+                let status = watch.status;
+
+                if (episodes === watch.anime.episodes_total) {
+                    status = 'completed';
+                }
+
+                if (!watch.episodes && watch.status === 'planned') {
+                    status = 'watching';
+                }
+
+                mutateAddWatch({
+                    params: {
+                        ...watch,
+                        status,
+                        slug: watch.anime.slug,
+                        episodes,
+                    },
+                });
             }
-
-            if (!watch.episodes && watch.status === 'planned') {
-                status = 'watching';
-            }
-
-            mutateAddWatch({
-                params: {
-                    ...watch,
-                    status,
-                    slug: watch.anime.slug,
-                    episodes,
-                },
-            });
         }
     };
 
@@ -55,14 +58,16 @@ const WatchStats = () => {
         if (watch) {
             const episodes =
                 (variables?.params?.episodes || watch.episodes) - 1;
-
-            mutateAddWatch({
-                params: {
-                    ...watch,
-                    slug: watch.anime.slug,
-                    episodes,
-                },
-            });
+            
+            if (episodes >= 0) {
+                mutateAddWatch({
+                    params: {
+                        ...watch,
+                        slug: watch.anime.slug,
+                        episodes,
+                    },
+                });
+            }
         }
     };
 


### PR DESCRIPTION

https://github.com/hikka-io/hikka-next/assets/37798530/d679bf17-8eb2-4b1f-9fb0-e9109450ed21

Sometimes the number of episodes watched could be -1 or more than the total number, and this would cause a bad query error.

Although my solution can rather be called temporary, because it should be redone somehow, because now if the server responds to you slowly it can cause a bug when your watched episodes can jump +-3 episodes if you click quickly.