### PR TITLE
Rename title_ja/name_ja fields to title_original/name_original

### DIFF
--- a/src/features/edit/edit-content/details.tsx
+++ b/src/features/edit/edit-content/details.tsx
@@ -36,7 +36,7 @@ const Details: FC<Props> = ({ content }) => {
             </div>
             <div className="flex flex-col gap-2">
                 <Label className="text-muted-foreground">
-                    {'title_ja' in content ? 'Назва оригіналу' : 'Рідне імʼя'}
+                    {'title_original' in content ? 'Назва' : 'Імʼя'} першоджерела
                 </Label>
                 <P className="text-sm">{title_ja || '-'}</P>
             </div>

--- a/src/features/edit/edit-content/details.tsx
+++ b/src/features/edit/edit-content/details.tsx
@@ -20,6 +20,8 @@ const Details: FC<Props> = ({ content }) => {
                 ? content.name_ja
                 : content.name_native;
 
+    const isPerson = content.data_type === 'person' || content.data_type === 'character';
+
     return (
         <div className="flex flex-col gap-4 rounded-md border border-secondary/60 bg-secondary/30 p-4">
             <div className="flex flex-col gap-2">
@@ -36,7 +38,7 @@ const Details: FC<Props> = ({ content }) => {
             </div>
             <div className="flex flex-col gap-2">
                 <Label className="text-muted-foreground">
-                    {'title_original' in content ? 'Назва' : 'Імʼя'} першоджерела
+                    {isPerson ? 'Імʼя' : 'Назва'} першоджерела
                 </Label>
                 <P className="text-sm">{title_ja || '-'}</P>
             </div>

--- a/src/utils/constants/edit.ts
+++ b/src/utils/constants/edit.ts
@@ -14,8 +14,8 @@ export const ANIME_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         },
         {
             slug: 'title_ja',
-            title: 'Японською',
-            placeholder: 'Введіть назву японською',
+            title: 'Першоджерела',
+            placeholder: 'Введіть назву першоджерела',
             type: 'input',
         },
     ],
@@ -66,8 +66,8 @@ export const MANGA_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         },
         {
             slug: 'title_original',
-            title: 'Японською',
-            placeholder: 'Введіть назву японською',
+            title: 'Першоджерела',
+            placeholder: 'Введіть назву першоджерела',
             type: 'input',
         },
     ],
@@ -118,8 +118,8 @@ export const NOVEL_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         },
         {
             slug: 'title_original',
-            title: 'Японською',
-            placeholder: 'Введіть назву японською',
+            title: 'Першоджерела',
+            placeholder: 'Введіть назву першоджерела',
             type: 'input',
         },
     ],
@@ -173,7 +173,7 @@ export const EDIT_PARAMS: Record<
     title_original: 'Назва JA',
     synopsis_ua: 'Опис UA',
     synopsis_en: 'Опис EN',
-    name_native: 'Рідне імʼя',
+    name_native: 'Назва першоджерела',
 };
 
 export const CHARACTER_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
@@ -192,8 +192,8 @@ export const CHARACTER_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         },
         {
             slug: 'name_ja',
-            title: 'Японською',
-            placeholder: 'Введіть імʼя японською',
+            title: 'Першоджерела',
+            placeholder: 'Введіть імʼя першоджерела',
             type: 'input',
         },
     ],
@@ -240,7 +240,7 @@ export const PERSON_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         {
             slug: 'name_native',
             title: 'Рідною',
-            placeholder: 'Введіть рідне імʼя',
+            placeholder: 'Введіть імʼя першоджерела',
             type: 'input',
         },
     ],

--- a/src/utils/constants/edit.ts
+++ b/src/utils/constants/edit.ts
@@ -192,8 +192,8 @@ export const CHARACTER_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         },
         {
             slug: 'name_ja',
-            title: 'Першоджерела',
-            placeholder: 'Введіть імʼя першоджерела',
+            title: 'Японською',
+            placeholder: 'Введіть імʼя японською',
             type: 'input',
         },
     ],

--- a/src/utils/constants/edit.ts
+++ b/src/utils/constants/edit.ts
@@ -14,8 +14,8 @@ export const ANIME_EDIT_PARAMS: Record<string, Hikka.EditParam[]> = {
         },
         {
             slug: 'title_ja',
-            title: 'Першоджерела',
-            placeholder: 'Введіть назву першоджерела',
+            title: 'Японською',
+            placeholder: 'Введіть назву японською',
             type: 'input',
         },
     ],


### PR DESCRIPTION
Виправив непрацюючу логіку Label для оригінальної назви edit-content/details.tsx

title_ja -> title_original (title_ja більше не існує в content)

Поправив edit.ts
Для всіх випадків(Новела, Аніме, Манга)

title: Японською -> Першоджерела

Також виправив плейсхолдер

Введіть назву японською - > Введіть назву першоджерела