### PR TITLE
fix: the link wouldn't open when pressed

### DIFF
--- a/src/features/users/user-title.component.tsx
+++ b/src/features/users/user-title.component.tsx
@@ -51,7 +51,6 @@ const UserTitle = () => {
             </div>
             {user.description && (
                 <MDViewer
-                    preview
                     className="line-clamp-4 text-sm text-muted-foreground"
                 >
                     {user.description}


### PR DESCRIPTION
The links in the profile description did not open
[bug](https://t.me/hikka_io_chat/7/129185)

now:
![image](https://github.com/user-attachments/assets/62b3f7be-707d-4bc7-b310-9b5f423216e9)
