### PR TITLE
web/fix: alignment of local navbars and hide divider with edit button

### DIFF
--- a/apps/web/src/features/anime/anime-list/anime-list.component.tsx
+++ b/apps/web/src/features/anime/anime-list/anime-list.component.tsx
@@ -136,7 +136,7 @@ const AnimeList: FC<Props> = () => {
                 />
             )}
             {list && pagination && pagination.pages > 1 && (
-                <div className="sticky bottom-4 z-10 flex items-center justify-center">
+                <div className="sticky bottom-4 z-10 flex items-center w-fit mx-auto">
                     <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                         <Pagination
                             page={pagination.page}

--- a/apps/web/src/features/anime/anime-view/anime-navbar/anime-navbar.component.tsx
+++ b/apps/web/src/features/anime/anime-view/anime-navbar/anime-navbar.component.tsx
@@ -61,16 +61,17 @@ const AnimeNavbar: FC<Props> = ({ className }) => {
                     </TooltipTrigger>
                     <TooltipContent>Коментарі</TooltipContent>
                 </Tooltip>
-                <div className="bg-secondary h-full w-px" />
-
                 {loggedUser && (
-                    <EditButton
-                        key={String(params.slug)}
-                        slug={String(params.slug)}
-                        content_type={ContentTypeEnum.ANIME}
-                        size="icon-md"
-                        variant="ghost"
-                    />
+                    <>
+                        <div className="bg-secondary h-full w-px" />
+                        <EditButton
+                            key={String(params.slug)}
+                            slug={String(params.slug)}
+                            content_type={ContentTypeEnum.ANIME}
+                            size="icon-md"
+                            variant="ghost"
+                        />
+                    </>
                 )}
             </Card>
         </div>

--- a/apps/web/src/features/anime/anime-view/anime-navbar/anime-navbar.component.tsx
+++ b/apps/web/src/features/anime/anime-view/anime-navbar/anime-navbar.component.tsx
@@ -34,10 +34,7 @@ const AnimeNavbar: FC<Props> = ({ className }) => {
 
     return (
         <div
-            className={cn(
-                'sticky bottom-4 z-10 flex justify-center',
-                className,
-            )}
+            className={cn('sticky bottom-4 z-10 flex w-fit mx-auto', className)}
         >
             <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                 <WatchlistButton

--- a/apps/web/src/features/articles/article-view/article-navbar/article-navbar.component.tsx
+++ b/apps/web/src/features/articles/article-view/article-navbar/article-navbar.component.tsx
@@ -41,7 +41,7 @@ const ArticleNavbar: FC<Props> = () => {
     }
 
     return (
-        <div className="sticky bottom-4 z-10 flex justify-center">
+        <div className="sticky bottom-4 z-10 flex w-fit mx-auto">
             <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                 {article?.category !== 'system' && (
                     <ArticleVote article={article!} />

--- a/apps/web/src/features/collections/collection-view/collection-navbar/collection-navbar.component.tsx
+++ b/apps/web/src/features/collections/collection-view/collection-navbar/collection-navbar.component.tsx
@@ -29,7 +29,7 @@ const CollectionNavbar: FC<Props> = () => {
     });
 
     return (
-        <div className="sticky bottom-4 z-10 flex justify-center">
+        <div className="sticky bottom-4 z-10 flex w-fit mx-auto">
             <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                 <CollectionVote collection={collection!} />
                 {collection && (

--- a/apps/web/src/features/manga/manga-list/manga-list.component.tsx
+++ b/apps/web/src/features/manga/manga-list/manga-list.component.tsx
@@ -122,7 +122,7 @@ const MangaList: FC<Props> = () => {
                 />
             )}
             {list && pagination && pagination.pages > 1 && (
-                <div className="sticky bottom-4 z-10 flex items-center justify-center">
+                <div className="sticky bottom-4 z-10 flex items-center w-fit mx-auto">
                     <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                         <Pagination
                             page={pagination.page}

--- a/apps/web/src/features/manga/manga-view/manga-navbar/manga-navbar.component.tsx
+++ b/apps/web/src/features/manga/manga-view/manga-navbar/manga-navbar.component.tsx
@@ -34,10 +34,7 @@ const MangaNavbar: FC<Props> = ({ className }) => {
 
     return (
         <div
-            className={cn(
-                'sticky bottom-4 z-10 flex justify-center',
-                className,
-            )}
+            className={cn('sticky bottom-4 z-10 flex w-fit mx-auto', className)}
         >
             <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                 <ReadlistButton

--- a/apps/web/src/features/manga/manga-view/manga-navbar/manga-navbar.component.tsx
+++ b/apps/web/src/features/manga/manga-view/manga-navbar/manga-navbar.component.tsx
@@ -62,15 +62,17 @@ const MangaNavbar: FC<Props> = ({ className }) => {
                     </TooltipTrigger>
                     <TooltipContent>Коментарі</TooltipContent>
                 </Tooltip>
-                <div className="bg-secondary h-full w-px" />
                 {loggedUser && (
-                    <EditButton
-                        key={String(params.slug)}
-                        slug={String(params.slug)}
-                        content_type={ContentTypeEnum.MANGA}
-                        size="icon-md"
-                        variant="ghost"
-                    />
+                    <>
+                        <div className="bg-secondary h-full w-px" />
+                        <EditButton
+                            key={String(params.slug)}
+                            slug={String(params.slug)}
+                            content_type={ContentTypeEnum.MANGA}
+                            size="icon-md"
+                            variant="ghost"
+                        />
+                    </>
                 )}
             </Card>
         </div>

--- a/apps/web/src/features/novel/novel-list/novel-list.component.tsx
+++ b/apps/web/src/features/novel/novel-list/novel-list.component.tsx
@@ -122,7 +122,7 @@ const NovelList: FC<Props> = () => {
                 />
             )}
             {list && pagination && pagination.pages > 1 && (
-                <div className="sticky bottom-4 z-10 flex items-center justify-center">
+                <div className="sticky bottom-4 z-10 flex items-center w-fit mx-auto">
                     <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                         <Pagination
                             page={pagination.page}

--- a/apps/web/src/features/novel/novel-view/novel-navbar/novel-navbar.component.tsx
+++ b/apps/web/src/features/novel/novel-view/novel-navbar/novel-navbar.component.tsx
@@ -34,10 +34,7 @@ const NovelNavbar: FC<Props> = ({ className }) => {
 
     return (
         <div
-            className={cn(
-                'sticky bottom-4 z-10 flex justify-center',
-                className,
-            )}
+            className={cn('sticky bottom-4 z-10 flex w-fit mx-auto', className)}
         >
             <Card className="bg-secondary/60 flex-row gap-2 border-none px-3 py-2 backdrop-blur-xl">
                 <ReadlistButton

--- a/apps/web/src/features/novel/novel-view/novel-navbar/novel-navbar.component.tsx
+++ b/apps/web/src/features/novel/novel-view/novel-navbar/novel-navbar.component.tsx
@@ -59,15 +59,17 @@ const NovelNavbar: FC<Props> = ({ className }) => {
                     </TooltipTrigger>
                     <TooltipContent>Коментарі</TooltipContent>
                 </Tooltip>
-                <div className="bg-secondary h-full w-px" />
                 {loggedUser && (
-                    <EditButton
-                        key={String(params.slug)}
-                        slug={String(params.slug)}
-                        content_type={ContentTypeEnum.NOVEL}
-                        size="icon-md"
-                        variant="ghost"
-                    />
+                    <>
+                        <div className="bg-secondary h-full w-px" />
+                        <EditButton
+                            key={String(params.slug)}
+                            slug={String(params.slug)}
+                            content_type={ContentTypeEnum.NOVEL}
+                            size="icon-md"
+                            variant="ghost"
+                        />
+                    </>
                 )}
             </Card>
         </div>


### PR DESCRIPTION
Fixes local navbars and pagination navbar click-through empty space. And fixes divider inside local navbars, now it is hidden with edit button, when user isn't logged in

## Before:

https://github.com/user-attachments/assets/1a14dba4-5f9a-4440-b278-6a43125bd5c0

## After:

https://github.com/user-attachments/assets/5e87ad4d-4eb0-4243-83b5-6cd878d7387b

