### PR TITLE
Fix: anime auto status determine

### DIFF
--- a/apps/web/src/features/anime/anime-view/actions/watch-stats.tsx
+++ b/apps/web/src/features/anime/anime-view/actions/watch-stats.tsx
@@ -49,12 +49,12 @@ const WatchStats = () => {
 
             let status = updatedWatch?.status ?? watch.status;
 
-            if (episodes === watch.anime.episodes_total) {
-                status = WatchStatusEnum.COMPLETED;
+            if (!watch.epsodes && watch.status === WatchStatusEnum.PLANNED) {
+                status = WatchStatusEnum.WATCHING;
             }
 
-            if (!watch.episodes && watch.status === WatchStatusEnum.PLANNED) {
-                status = WatchStatusEnum.WATCHING;
+            if (episodes === watch.anime.episodes_total) {
+                status = WatchStatusEnum.COMPLETED;
             }
 
             setUpdatedWatch({


### PR DESCRIPTION
When you watch a single-episode show and click the “Add episode” button, the status changes to ‘Watching’ instead of “Completed.”