### PR TITLE
Feature: Add current authorized apps

### DIFF
--- a/apps/web/src/features/settings/applications/applications.tsx
+++ b/apps/web/src/features/settings/applications/applications.tsx
@@ -2,29 +2,52 @@ import { listUserClientsInfiniteOptions } from '@hikka/api';
 
 import MaterialSymbolsAppsRounded from '@/components/icons/material-symbols/MaterialSymbolsAppsRounded';
 import EmptyState from '@/components/ui/empty-state';
+import { Header, HeaderContainer, HeaderTitle } from '@/components/ui/header';
 import { useInfiniteList } from '@/utils/api/use-infinite-list';
 
+import AuthorizedAppsSettings from './authorized-apps';
 import ApplicationItem from './components/application-item';
 
 const ApplicationsSettings = () => {
     const { list } = useInfiniteList(listUserClientsInfiniteOptions());
 
     return (
-        <div className="flex w-full flex-col gap-6">
-            {list && list.length > 0 ? (
-                <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
-                    {list?.map((item) => (
-                        <ApplicationItem key={item.reference} client={item} />
-                    ))}
-                </div>
-            ) : (
-                <EmptyState
-                    bordered
-                    icon={<MaterialSymbolsAppsRounded />}
-                    title="Не знайдено застосунків"
-                    description="Створіть свій перший застосунок для сторонньої авторизації"
-                />
-            )}
+        <div className="flex w-full flex-col gap-8">
+            <div className="flex w-full flex-col gap-4">
+                <Header>
+                    <HeaderContainer>
+                        <HeaderTitle variant="h4">
+                            Авторизовані застосунки
+                        </HeaderTitle>
+                    </HeaderContainer>
+                </Header>
+                <AuthorizedAppsSettings />
+            </div>
+
+            <div className="flex w-full flex-col gap-4">
+                <Header>
+                    <HeaderContainer>
+                        <HeaderTitle variant="h4">Мої застосунки</HeaderTitle>
+                    </HeaderContainer>
+                </Header>
+                {list && list.length > 0 ? (
+                    <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+                        {list?.map((item) => (
+                            <ApplicationItem
+                                key={item.reference}
+                                client={item}
+                            />
+                        ))}
+                    </div>
+                ) : (
+                    <EmptyState
+                        bordered
+                        icon={<MaterialSymbolsAppsRounded />}
+                        title="Не знайдено застосунків"
+                        description="Створіть свій перший застосунок для сторонньої авторизації"
+                    />
+                )}
+            </div>
         </div>
     );
 };

--- a/apps/web/src/features/settings/applications/authorized-apps.tsx
+++ b/apps/web/src/features/settings/applications/authorized-apps.tsx
@@ -1,20 +1,69 @@
-import { thirdPartyAuthTokensInfiniteOptions } from '@hikka/api';
+import { useMemo } from 'react';
+
+import { type AuthTokenInfoResponse, thirdPartyAuthTokensInfiniteOptions } from '@hikka/api';
 
 import MaterialSymbolsAppsRounded from '@/components/icons/material-symbols/MaterialSymbolsAppsRounded';
 import EmptyState from '@/components/ui/empty-state';
 import { useInfiniteList } from '@/utils/api/use-infinite-list';
 
-import AuthorizedAppItem from './components/authorized-app-item';
+import AuthorizedAppGroup from './components/authorized-app-group';
+
+type AppGroup = {
+    key: string;
+    name: string;
+    description?: string | null;
+    verified?: boolean;
+    tokens: AuthTokenInfoResponse[];
+};
 
 const AuthorizedAppsSettings = () => {
     const { list } = useInfiniteList(thirdPartyAuthTokensInfiniteOptions());
 
+    const groups = useMemo<AppGroup[]>(() => {
+        if (!list) return [];
+
+        const map = new Map<string, AppGroup>();
+
+        for (const token of list) {
+            const key =
+                token.client?.reference ??
+                token.client?.name ??
+                'unknown';
+
+            const existing = map.get(key);
+            if (existing) {
+                existing.tokens.push(token);
+            } else {
+                map.set(key, {
+                    key,
+                    name: token.client?.name ?? 'Невідомий застосунок',
+                    description: token.client?.description,
+                    verified: token.client?.verified,
+                    tokens: [token],
+                });
+            }
+        }
+
+        // Newest authorization first within each group
+        for (const group of map.values()) {
+            group.tokens.sort((a, b) => (b.created ?? 0) - (a.created ?? 0));
+        }
+
+        return Array.from(map.values());
+    }, [list]);
+
     return (
         <div className="flex w-full flex-col gap-4">
-            {list && list.length > 0 ? (
+            {groups.length > 0 ? (
                 <div className="flex flex-col gap-4">
-                    {list.map((item) => (
-                        <AuthorizedAppItem key={item.reference} token={item} />
+                    {groups.map((group) => (
+                        <AuthorizedAppGroup
+                            key={group.key}
+                            appName={group.name}
+                            appDescription={group.description}
+                            verified={group.verified}
+                            tokens={group.tokens}
+                        />
                     ))}
                 </div>
             ) : (

--- a/apps/web/src/features/settings/applications/authorized-apps.tsx
+++ b/apps/web/src/features/settings/applications/authorized-apps.tsx
@@ -1,0 +1,32 @@
+import { thirdPartyAuthTokensInfiniteOptions } from '@hikka/api';
+
+import MaterialSymbolsAppsRounded from '@/components/icons/material-symbols/MaterialSymbolsAppsRounded';
+import EmptyState from '@/components/ui/empty-state';
+import { useInfiniteList } from '@/utils/api/use-infinite-list';
+
+import AuthorizedAppItem from './components/authorized-app-item';
+
+const AuthorizedAppsSettings = () => {
+    const { list } = useInfiniteList(thirdPartyAuthTokensInfiniteOptions());
+
+    return (
+        <div className="flex w-full flex-col gap-4">
+            {list && list.length > 0 ? (
+                <div className="flex flex-col gap-4">
+                    {list.map((item) => (
+                        <AuthorizedAppItem key={item.reference} token={item} />
+                    ))}
+                </div>
+            ) : (
+                <EmptyState
+                    bordered
+                    icon={<MaterialSymbolsAppsRounded />}
+                    title="Немає авторизованих застосунків"
+                    description="Тут з’являться застосунки, яким ви надали доступ до свого акаунту"
+                />
+            )}
+        </div>
+    );
+};
+
+export default AuthorizedAppsSettings;

--- a/apps/web/src/features/settings/applications/components/application-item.tsx
+++ b/apps/web/src/features/settings/applications/components/application-item.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 const ApplicationItem: FC<Props> = ({ client }) => {
     return (
-        <Card className="justify-between gap-6">
+        <Card className="justify-between gap-6 bg-secondary/20 backdrop-blur">
             <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-2">
                     <h5 className="line-clamp-1">{client.name}</h5>

--- a/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
@@ -155,7 +155,7 @@ const AuthorizedAppGroup: FC<Props> = ({
     });
 
     return (
-        <Card className="flex-col gap-4">
+        <Card className="flex-col gap-4 bg-secondary/20 backdrop-blur">
             <Collapsible defaultOpen={tokens.length === 1}>
                 <CollapsibleTrigger asChild>
                     <div className="flex cursor-pointer items-center justify-between gap-4">

--- a/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { LucideChevronsUpDown } from 'lucide-react';
 
+import MaterialSymbolsDeleteForeverRounded from '@/components/icons/material-symbols/MaterialSymbolsDeleteForeverRounded';
 import MaterialSymbolsVerifiedRounded from '@/components/icons/material-symbols/MaterialSymbolsVerifiedRounded';
 import { Button } from '@/components/ui/button';
 import Card from '@/components/ui/card';
@@ -46,7 +47,8 @@ type Props = {
     tokens: AuthTokenInfoResponse[];
 };
 
-const SessionRow: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
+// Declared as a standalone component at module level to adhere to React Rules of Hooks
+const AuthorizedAppItem: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
     const queryClient = useQueryClient();
 
     const { mutate: revokeToken, isPending: isRevoking } = useMutation({
@@ -85,12 +87,15 @@ const SessionRow: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
                 <AlertDialogTrigger asChild>
                     <Button
                         className="shrink-0"
-                        variant="destructive"
-                        size="md"
+                        variant="outline"
+                        size="icon-sm"
                         disabled={isRevoking}
                     >
-                        {isRevoking && <Spinner />}
-                        Відкликати
+                        {isRevoking ? (
+                            <Spinner />
+                        ) : (
+                            <MaterialSymbolsDeleteForeverRounded className="size-4" />
+                        )}
                     </Button>
                 </AlertDialogTrigger>
                 <AlertDialogContent>
@@ -121,12 +126,40 @@ const AuthorizedAppGroup: FC<Props> = ({
     verified,
     tokens,
 }) => {
+    const queryClient = useQueryClient();
+
+    const { mutate: revokeAll, isPending: isRevokingAll } = useMutation({
+        mutationFn: async () => {
+            const { mutationFn } = revokeTokenMutation();
+            if (!mutationFn) return;
+
+            // Revoke all tokens associated with this application concurrently
+            await Promise.all(
+                tokens.map((token) =>
+                    mutationFn(
+                        { path: { token_reference: token.reference } },
+                        undefined as any,
+                    ),
+                ),
+            );
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: thirdPartyAuthTokensInfiniteOptions().queryKey,
+            });
+            toast.success('Усі сеанси доступу успішно відкликано.');
+        },
+        onError: () => {
+            toast.error('Не вдалося відкликати всі сеанси. Спробуйте ще раз.');
+        },
+    });
+
     return (
         <Card className="flex-col gap-4">
             <Collapsible defaultOpen={tokens.length === 1}>
                 <CollapsibleTrigger asChild>
-                    <div className="flex cursor-pointer flex-col gap-2">
-                        <div className="flex items-center justify-between gap-2">
+                    <div className="flex cursor-pointer items-center justify-between gap-4">
+                        <div className="flex flex-col gap-2 flex-1">
                             <div className="flex items-center gap-2">
                                 <h5 className="line-clamp-1">{appName}</h5>
                                 {verified && (
@@ -149,6 +182,51 @@ const AuthorizedAppGroup: FC<Props> = ({
                                     </span>
                                 )}
                             </div>
+                            {appDescription && (
+                                <p className="line-clamp-2 text-muted-foreground text-sm">
+                                    {appDescription}
+                                </p>
+                            )}
+                        </div>
+                        <div className="flex items-center gap-2 shrink-0">
+                            <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                    <Button
+                                        className="shrink-0"
+                                        variant="destructive"
+                                        size="md"
+                                        disabled={isRevokingAll}
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                        }}
+                                    >
+                                        {isRevokingAll && <Spinner />}
+                                        Відкликати всі
+                                    </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+                                    <AlertDialogHeader>
+                                        <AlertDialogTitle>
+                                            Відкликати всі доступи для{' '}
+                                            {appName}?
+                                        </AlertDialogTitle>
+                                        <AlertDialogDescription>
+                                            Усі активні сеанси авторизації для
+                                            цього застосунку будуть завершені, і
+                                            застосунку знадобиться повторна
+                                            авторизація.
+                                        </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                        <AlertDialogCancel>
+                                            Відмінити
+                                        </AlertDialogCancel>
+                                        <AlertDialogAction onClick={() => revokeAll()}>
+                                            Підтвердити
+                                        </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                </AlertDialogContent>
+                            </AlertDialog>
                             <Button
                                 variant="ghost"
                                 size="md"
@@ -158,17 +236,12 @@ const AuthorizedAppGroup: FC<Props> = ({
                                 <span className="sr-only">Toggle</span>
                             </Button>
                         </div>
-                        {appDescription && (
-                            <p className="line-clamp-2 text-muted-foreground text-sm">
-                                {appDescription}
-                            </p>
-                        )}
                     </div>
                 </CollapsibleTrigger>
-                <CollapsibleContent className="w-full overflow-hidden mt-2 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+                <CollapsibleContent className="w-full overflow-hidden mt-4 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
                     <div className="flex flex-col">
                         {tokens.map((token) => (
-                            <SessionRow key={token.reference} token={token} />
+                            <AuthorizedAppItem key={token.reference} token={token} />
                         ))}
                     </div>
                 </CollapsibleContent>

--- a/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
@@ -1,0 +1,157 @@
+import type { FC } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns/format';
+import { toast } from 'sonner';
+
+import {
+    type AuthTokenInfoResponse,
+    revokeTokenMutation,
+    thirdPartyAuthTokensInfiniteOptions,
+} from '@hikka/api';
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import MaterialSymbolsVerifiedRounded from '@/components/icons/material-symbols/MaterialSymbolsVerifiedRounded';
+import { Button } from '@/components/ui/button';
+import Card from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import Spinner from '@/components/ui/spinner';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type Props = {
+    appName: string;
+    appDescription?: string | null;
+    verified?: boolean;
+    tokens: AuthTokenInfoResponse[];
+};
+
+const SessionRow: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
+    const queryClient = useQueryClient();
+
+    const { mutate: revokeToken, isPending: isRevoking } = useMutation({
+        ...revokeTokenMutation(),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: thirdPartyAuthTokensInfiniteOptions().queryKey,
+            });
+            toast.success('Доступ успішно відкликано.');
+        },
+        onError: () => {
+            toast.error('Не вдалося відкликати доступ. Спробуйте ще раз.');
+        },
+    });
+
+    const handleRevoke = () => {
+        revokeToken({ path: { token_reference: token.reference } });
+    };
+
+    return (
+        <div className="flex items-center justify-between gap-4 border-border border-t py-3 first:border-t-0 first:pt-0 last:pb-0">
+            <div className="flex flex-col">
+                <p className="text-sm">
+                    {token.created
+                        ? format(
+                              new Date(token.created * 1000),
+                              'd MMMM yyyy, HH:mm',
+                          )
+                        : 'Дата невідома'}
+                </p>
+                <p className="text-muted-foreground text-xs opacity-60">
+                    {token.reference}
+                </p>
+            </div>
+            <AlertDialog>
+                <AlertDialogTrigger asChild>
+                    <Button
+                        className="shrink-0"
+                        variant="destructive"
+                        size="md"
+                        disabled={isRevoking}
+                    >
+                        {isRevoking && <Spinner />}
+                        Відкликати
+                    </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            Відкликати цей доступ?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Цей сеанс авторизації буде завершено, і
+                            застосунку знадобиться повторна авторизація.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Відмінити</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleRevoke}>
+                            Підтвердити
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    );
+};
+
+const AuthorizedAppGroup: FC<Props> = ({
+    appName,
+    appDescription,
+    verified,
+    tokens,
+}) => {
+    return (
+        <Card className="flex-col gap-4">
+            <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                    <h5 className="line-clamp-1">{appName}</h5>
+                    {verified && (
+                        <Tooltip delayDuration={0}>
+                            <TooltipTrigger>
+                                <div className="rounded-sm border border-border bg-secondary/20 p-1 backdrop-blur">
+                                    <MaterialSymbolsVerifiedRounded className="text-primary-foreground" />
+                                </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <Label className="text-sm">
+                                    Верифіковано
+                                </Label>
+                            </TooltipContent>
+                        </Tooltip>
+                    )}
+                    {tokens.length > 1 && (
+                        <span className="rounded-sm border border-border bg-secondary/20 px-1.5 py-0.5 text-muted-foreground text-xs">
+                            {tokens.length} сеанси
+                        </span>
+                    )}
+                </div>
+                {appDescription && (
+                    <p className="line-clamp-2 text-muted-foreground text-sm">
+                        {appDescription}
+                    </p>
+                )}
+            </div>
+            <div className="flex flex-col">
+                {tokens.map((token) => (
+                    <SessionRow key={token.reference} token={token} />
+                ))}
+            </div>
+        </Card>
+    );
+};
+
+export default AuthorizedAppGroup;

--- a/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
@@ -21,9 +21,16 @@ import {
     AlertDialogTitle,
     AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { LucideChevronsUpDown } from 'lucide-react';
+
 import MaterialSymbolsVerifiedRounded from '@/components/icons/material-symbols/MaterialSymbolsVerifiedRounded';
 import { Button } from '@/components/ui/button';
 import Card from '@/components/ui/card';
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import { Label } from '@/components/ui/label';
 import Spinner from '@/components/ui/spinner';
 import {
@@ -116,40 +123,56 @@ const AuthorizedAppGroup: FC<Props> = ({
 }) => {
     return (
         <Card className="flex-col gap-4">
-            <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-2">
-                    <h5 className="line-clamp-1">{appName}</h5>
-                    {verified && (
-                        <Tooltip delayDuration={0}>
-                            <TooltipTrigger>
-                                <div className="rounded-sm border border-border bg-secondary/20 p-1 backdrop-blur">
-                                    <MaterialSymbolsVerifiedRounded className="text-primary-foreground" />
-                                </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <Label className="text-sm">
-                                    Верифіковано
-                                </Label>
-                            </TooltipContent>
-                        </Tooltip>
-                    )}
-                    {tokens.length > 1 && (
-                        <span className="rounded-sm border border-border bg-secondary/20 px-1.5 py-0.5 text-muted-foreground text-xs">
-                            {tokens.length} сеанси
-                        </span>
-                    )}
-                </div>
-                {appDescription && (
-                    <p className="line-clamp-2 text-muted-foreground text-sm">
-                        {appDescription}
-                    </p>
-                )}
-            </div>
-            <div className="flex flex-col">
-                {tokens.map((token) => (
-                    <SessionRow key={token.reference} token={token} />
-                ))}
-            </div>
+            <Collapsible defaultOpen={tokens.length === 1}>
+                <CollapsibleTrigger asChild>
+                    <div className="flex cursor-pointer flex-col gap-2">
+                        <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-2">
+                                <h5 className="line-clamp-1">{appName}</h5>
+                                {verified && (
+                                    <Tooltip delayDuration={0}>
+                                        <TooltipTrigger>
+                                            <div className="rounded-sm border border-border bg-secondary/20 p-1 backdrop-blur">
+                                                <MaterialSymbolsVerifiedRounded className="text-primary-foreground" />
+                                            </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            <Label className="text-sm">
+                                                Верифіковано
+                                            </Label>
+                                        </TooltipContent>
+                                    </Tooltip>
+                                )}
+                                {tokens.length > 1 && (
+                                    <span className="rounded-sm border border-border bg-secondary/20 px-1.5 py-0.5 text-muted-foreground text-xs">
+                                        {tokens.length} сеанси
+                                    </span>
+                                )}
+                            </div>
+                            <Button
+                                variant="ghost"
+                                size="md"
+                                className="w-9 p-0"
+                            >
+                                <LucideChevronsUpDown className="size-4" />
+                                <span className="sr-only">Toggle</span>
+                            </Button>
+                        </div>
+                        {appDescription && (
+                            <p className="line-clamp-2 text-muted-foreground text-sm">
+                                {appDescription}
+                            </p>
+                        )}
+                    </div>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="w-full overflow-hidden mt-2 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+                    <div className="flex flex-col">
+                        {tokens.map((token) => (
+                            <SessionRow key={token.reference} token={token} />
+                        ))}
+                    </div>
+                </CollapsibleContent>
+            </Collapsible>
         </Card>
     );
 };

--- a/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
@@ -47,7 +47,6 @@ type Props = {
     tokens: AuthTokenInfoResponse[];
 };
 
-// Declared as a standalone component at module level to adhere to React Rules of Hooks
 const AuthorizedAppItem: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
     const queryClient = useQueryClient();
 
@@ -104,8 +103,8 @@ const AuthorizedAppItem: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
                             Відкликати цей доступ?
                         </AlertDialogTitle>
                         <AlertDialogDescription>
-                            Цей сеанс авторизації буде завершено, і
-                            застосунку знадобиться повторна авторизація.
+                            Цей сеанс авторизації буде завершено, і застосунку
+                            знадобиться повторна авторизація.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -116,6 +115,84 @@ const AuthorizedAppItem: FC<{ token: AuthTokenInfoResponse }> = ({ token }) => {
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
+        </div>
+    );
+};
+
+const RevokeAllDialog: FC<{
+    appName: string;
+    isRevokingAll: boolean;
+    onRevokeAll: () => void;
+}> = ({ appName, isRevokingAll, onRevokeAll }) => {
+    return (
+        <AlertDialog>
+            <AlertDialogTrigger asChild>
+                <Button
+                    className="shrink-0"
+                    variant="destructive"
+                    size="md"
+                    disabled={isRevokingAll}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    {isRevokingAll && <Spinner />}
+                    Відкликати всі
+                </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>
+                        Відкликати всі доступи для {appName}?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                        Усі активні сеанси авторизації для цього застосунку
+                        будуть завершені, і застосунку знадобиться повторна
+                        авторизація.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Відмінити</AlertDialogCancel>
+                    <AlertDialogAction onClick={onRevokeAll}>
+                        Підтвердити
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+const AppGroupHeaderInfo: FC<{
+    appName: string;
+    appDescription?: string | null;
+    verified?: boolean;
+    tokenCount: number;
+}> = ({ appName, appDescription, verified, tokenCount }) => {
+    return (
+        <div className="flex flex-1 flex-col gap-2">
+            <div className="flex items-center gap-2">
+                <h5 className="line-clamp-1">{appName}</h5>
+                {verified && (
+                    <Tooltip delayDuration={0}>
+                        <TooltipTrigger>
+                            <div className="rounded-sm border border-border bg-secondary/20 p-1 backdrop-blur">
+                                <MaterialSymbolsVerifiedRounded className="text-primary-foreground" />
+                            </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <Label className="text-sm">Верифіковано</Label>
+                        </TooltipContent>
+                    </Tooltip>
+                )}
+                {tokenCount > 1 && (
+                    <span className="rounded-sm border border-border bg-secondary/20 px-1.5 py-0.5 text-muted-foreground text-xs">
+                        {tokenCount} сеанси
+                    </span>
+                )}
+            </div>
+            {appDescription && (
+                <p className="line-clamp-2 text-muted-foreground text-sm">
+                    {appDescription}
+                </p>
+            )}
         </div>
     );
 };
@@ -133,7 +210,6 @@ const AuthorizedAppGroup: FC<Props> = ({
             const { mutationFn } = revokeTokenMutation();
             if (!mutationFn) return;
 
-            // Revoke all tokens associated with this application concurrently
             await Promise.all(
                 tokens.map((token) =>
                     mutationFn(
@@ -159,86 +235,26 @@ const AuthorizedAppGroup: FC<Props> = ({
             <Collapsible defaultOpen={tokens.length === 1}>
                 <CollapsibleTrigger asChild>
                     <div className="flex cursor-pointer items-center justify-between gap-4">
-                        <div className="flex flex-col gap-2 flex-1">
-                            <div className="flex items-center gap-2">
-                                <h5 className="line-clamp-1">{appName}</h5>
-                                {verified && (
-                                    <Tooltip delayDuration={0}>
-                                        <TooltipTrigger>
-                                            <div className="rounded-sm border border-border bg-secondary/20 p-1 backdrop-blur">
-                                                <MaterialSymbolsVerifiedRounded className="text-primary-foreground" />
-                                            </div>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                            <Label className="text-sm">
-                                                Верифіковано
-                                            </Label>
-                                        </TooltipContent>
-                                    </Tooltip>
-                                )}
-                                {tokens.length > 1 && (
-                                    <span className="rounded-sm border border-border bg-secondary/20 px-1.5 py-0.5 text-muted-foreground text-xs">
-                                        {tokens.length} сеанси
-                                    </span>
-                                )}
-                            </div>
-                            {appDescription && (
-                                <p className="line-clamp-2 text-muted-foreground text-sm">
-                                    {appDescription}
-                                </p>
-                            )}
-                        </div>
-                        <div className="flex items-center gap-2 shrink-0">
-                            <AlertDialog>
-                                <AlertDialogTrigger asChild>
-                                    <Button
-                                        className="shrink-0"
-                                        variant="destructive"
-                                        size="md"
-                                        disabled={isRevokingAll}
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                        }}
-                                    >
-                                        {isRevokingAll && <Spinner />}
-                                        Відкликати всі
-                                    </Button>
-                                </AlertDialogTrigger>
-                                <AlertDialogContent onClick={(e) => e.stopPropagation()}>
-                                    <AlertDialogHeader>
-                                        <AlertDialogTitle>
-                                            Відкликати всі доступи для{' '}
-                                            {appName}?
-                                        </AlertDialogTitle>
-                                        <AlertDialogDescription>
-                                            Усі активні сеанси авторизації для
-                                            цього застосунку будуть завершені, і
-                                            застосунку знадобиться повторна
-                                            авторизація.
-                                        </AlertDialogDescription>
-                                    </AlertDialogHeader>
-                                    <AlertDialogFooter>
-                                        <AlertDialogCancel>
-                                            Відмінити
-                                        </AlertDialogCancel>
-                                        <AlertDialogAction onClick={() => revokeAll()}>
-                                            Підтвердити
-                                        </AlertDialogAction>
-                                    </AlertDialogFooter>
-                                </AlertDialogContent>
-                            </AlertDialog>
-                            <Button
-                                variant="ghost"
-                                size="md"
-                                className="w-9 p-0"
-                            >
+                        <AppGroupHeaderInfo
+                            appName={appName}
+                            appDescription={appDescription}
+                            verified={verified}
+                            tokenCount={tokens.length}
+                        />
+                        <div className="flex shrink-0 items-center gap-2">
+                            <RevokeAllDialog
+                                appName={appName}
+                                isRevokingAll={isRevokingAll}
+                                onRevokeAll={() => revokeAll()}
+                            />
+                            <Button variant="ghost" size="md" className="w-9 p-0">
                                 <LucideChevronsUpDown className="size-4" />
                                 <span className="sr-only">Toggle</span>
                             </Button>
                         </div>
                     </div>
                 </CollapsibleTrigger>
-                <CollapsibleContent className="w-full overflow-hidden mt-4 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+                <CollapsibleContent className="mt-4 w-full overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
                     <div className="flex flex-col">
                         {tokens.map((token) => (
                             <AuthorizedAppItem key={token.reference} token={token} />

--- a/apps/web/src/features/settings/applications/components/authorized-app-item.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-item.tsx
@@ -1,0 +1,128 @@
+import type { FC } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns/format';
+import { toast } from 'sonner';
+
+import {
+    type AuthTokenInfoResponse,
+    revokeTokenMutation,
+    thirdPartyAuthTokensInfiniteOptions,
+} from '@hikka/api';
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import MaterialSymbolsVerifiedRounded from '@/components/icons/material-symbols/MaterialSymbolsVerifiedRounded';
+import { Button } from '@/components/ui/button';
+import Card from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import Spinner from '@/components/ui/spinner';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type Props = {
+    token: AuthTokenInfoResponse;
+};
+
+const AuthorizedAppItem: FC<Props> = ({ token }) => {
+    const queryClient = useQueryClient();
+
+    const { mutate: revokeToken, isPending: isRevoking } = useMutation({
+        ...revokeTokenMutation(),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: thirdPartyAuthTokensInfiniteOptions().queryKey,
+            });
+            toast.success('Доступ застосунку успішно відкликано.');
+        },
+        onError: () => {
+            toast.error('Не вдалося відкликати доступ. Спробуйте ще раз.');
+        },
+    });
+
+    const handleRevoke = () => {
+        revokeToken({ path: { token_reference: token.reference } });
+    };
+
+    return (
+        <Card className="flex-row items-center justify-between gap-4">
+            <div className="flex flex-col gap-2 overflow-hidden">
+                <div className="flex items-center gap-2">
+                    <h5 className="line-clamp-1">
+                        {token.client?.name ?? 'Невідомий застосунок'}
+                    </h5>
+                    {token.client?.verified && (
+                        <Tooltip delayDuration={0}>
+                            <TooltipTrigger>
+                                <div className="rounded-sm border border-border bg-secondary/20 p-1 backdrop-blur">
+                                    <MaterialSymbolsVerifiedRounded className="text-primary-foreground" />
+                                </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <Label className="text-sm">
+                                    Верифіковано
+                                </Label>
+                            </TooltipContent>
+                        </Tooltip>
+                    )}
+                </div>
+                {token.client?.description && (
+                    <p className="line-clamp-2 text-muted-foreground text-sm">
+                        {token.client.description}
+                    </p>
+                )}
+                {token.created && (
+                    <p className="text-muted-foreground text-xs opacity-60">
+                        Авторизовано{' '}
+                        {format(new Date(token.created * 1000), 'd MMMM yyyy')}
+                    </p>
+                )}
+            </div>
+            <AlertDialog>
+                <AlertDialogTrigger asChild>
+                    <Button
+                        className="shrink-0"
+                        variant="destructive"
+                        size="md"
+                        disabled={isRevoking}
+                    >
+                        {isRevoking && <Spinner />}
+                        Відкликати
+                    </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            Відкликати доступ для{' '}
+                            {token.client?.name ?? 'цього застосунку'}?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Застосунок втратить доступ до вашого акаунту і
+                            йому знадобиться повторна авторизація.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Відмінити</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleRevoke}>
+                            Підтвердити
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </Card>
+    );
+};
+
+export default AuthorizedAppItem;

--- a/apps/web/src/features/settings/index.ts
+++ b/apps/web/src/features/settings/index.ts
@@ -3,6 +3,7 @@
 // Profile Settings
 export { default as ProfileAppearance } from './appearance';
 // Applications Settings
+export { default as AuthorizedAppsSettings } from './applications/authorized-apps';
 export { default as ApplicationsSettings } from './applications/applications';
 export { default as ClientCreateButton } from './client-create-button';
 export { default as ProfileDescription } from './description';


### PR DESCRIPTION
Added a new section in Settings for managing authorized third-party applications.

Changes:
- Added authorized applications page with token grouping by client
- Implemented collapsible app groups - multi-token apps collapsed by default, single-token always expanded
- Entire header clickable to expand/collapse

<img width="1278" height="832" alt="image" src="https://github.com/user-attachments/assets/f2ccc069-3a35-4fb9-8b12-192b892bd405" />

https://github.com/user-attachments/assets/bf062d49-ca37-40e5-8544-19dd250ffaa0

