### PR TITLE
Minor adjustments to the settings in the Applications tab.

### DIFF
--- a/apps/web/src/features/settings/applications/applications.tsx
+++ b/apps/web/src/features/settings/applications/applications.tsx
@@ -7,6 +7,7 @@ import { useInfiniteList } from '@/utils/api/use-infinite-list';
 
 import AuthorizedAppsSettings from './authorized-apps';
 import ApplicationItem from './components/application-item';
+import ClientCreateButton from '../client-create-button';
 
 const ApplicationsSettings = () => {
     const { list } = useInfiniteList(listUserClientsInfiniteOptions());
@@ -28,6 +29,7 @@ const ApplicationsSettings = () => {
                 <Header>
                     <HeaderContainer>
                         <HeaderTitle variant="h4">Мої застосунки</HeaderTitle>
+                        <ClientCreateButton />
                     </HeaderContainer>
                 </Header>
                 {list && list.length > 0 ? (

--- a/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
+++ b/apps/web/src/features/settings/applications/components/authorized-app-group.tsx
@@ -232,7 +232,7 @@ const AuthorizedAppGroup: FC<Props> = ({
 
     return (
         <Card className="flex-col gap-4 bg-secondary/20 backdrop-blur">
-            <Collapsible defaultOpen={tokens.length === 1}>
+            <Collapsible defaultOpen={false}>
                 <CollapsibleTrigger asChild>
                     <div className="flex cursor-pointer items-center justify-between gap-4">
                         <AppGroupHeaderInfo

--- a/apps/web/src/routes/_pages/settings/applications.tsx
+++ b/apps/web/src/routes/_pages/settings/applications.tsx
@@ -6,7 +6,7 @@ import {
 } from '@hikka/api';
 
 import { Header, HeaderContainer, HeaderTitle } from '@/components/ui/header';
-import { ApplicationsSettings, ClientCreateButton } from '@/features/settings';
+import { ApplicationsSettings } from '@/features/settings';
 
 export const Route = createFileRoute('/_pages/settings/applications')({
     loader: async ({ context: { queryClient, apiClient } }) => {
@@ -28,12 +28,10 @@ function ApplicationsSettingsPage() {
                 <Header>
                     <HeaderContainer>
                         <HeaderTitle>Застосунки</HeaderTitle>
-                        <ClientCreateButton />
                     </HeaderContainer>
                 </Header>
                 <p className="text-muted-foreground text-sm">
-                    Підключіть OAuth авторизацію через hikka за допомогою
-                    застосунку (для розробників)
+                    Керуйте застосунками та їхнім доступом до вашого профілю
                 </p>
             </div>
             <ApplicationsSettings />


### PR DESCRIPTION
What's Changed:

- Moved "Create Application" button from the main header to the "My Applications" section header for better organization
- Updated page description to be more user-friendly
- Fixed authorized app groups to be collapsed by default (previously, groups with a single session were open by default)