### PR TITLE
Feature: Show exact comment date in styled tooltip on hover

### DIFF
--- a/apps/web/src/components/relative-time.tsx
+++ b/apps/web/src/components/relative-time.tsx
@@ -2,6 +2,11 @@ import type { FC } from 'react';
 
 import type { Locale } from 'date-fns';
 
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/utils/cn';
 import { formatTimestamp } from '@/utils/i18n';
 
@@ -16,14 +21,23 @@ const RelativeTime: FC<Props> = ({ value, locale, className }) => {
     const { label, full, iso } = formatTimestamp(value, Date.now(), locale);
 
     return (
-        <time
-            dateTime={iso}
-            title={full}
-            suppressHydrationWarning
-            className={cn('shrink-0 text-muted-foreground text-xs', className)}
-        >
-            {label}
-        </time>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <time
+                    dateTime={iso}
+                    suppressHydrationWarning
+                    className={cn(
+                        'shrink-0 text-muted-foreground text-xs',
+                        className,
+                    )}
+                >
+                    {label}
+                </time>
+            </TooltipTrigger>
+            <TooltipContent>
+                <p>{full}</p>
+            </TooltipContent>
+        </Tooltip>
     );
 };
 


### PR DESCRIPTION
Adds a styled tooltip to the comment timestamp that shows the exact publication date on hover.
<img width="403" height="196" alt="image" src="https://github.com/user-attachments/assets/819fac2c-0be7-4c64-a10d-a575f2dae54b" />
